### PR TITLE
FE HFS - Make size prop optional for windows

### DIFF
--- a/web/src/core/components/ConfirmDialogComponent.vue
+++ b/web/src/core/components/ConfirmDialogComponent.vue
@@ -19,8 +19,8 @@ import type { RelativeSize } from '../models/relativeSize'
 import DialogComponent from './DialogComponent.vue'
 
 defineProps<{
-  pos: RelativePosition
-  size: RelativeSize
+  pos?: RelativePosition | 'center'
+  size?: RelativeSize
   title: string
   message: string
   blocking?: boolean
@@ -31,5 +31,7 @@ defineProps<{
 .message {
   text-align: center;
   margin: 0;
+  padding-bottom: 2em;
+  white-space: pre-line;
 }
 </style>

--- a/web/src/core/components/DialogComponent.vue
+++ b/web/src/core/components/DialogComponent.vue
@@ -59,8 +59,8 @@ const emit = defineEmits<{
 }>()
 
 const props = defineProps<{
-  pos: RelativePosition
-  size: RelativeSize
+  pos?: RelativePosition | 'center'
+  size?: RelativeSize
   title?: string
   blocking?: boolean
   buttons: {

--- a/web/src/core/components/ErrorDialogComponent.vue
+++ b/web/src/core/components/ErrorDialogComponent.vue
@@ -19,8 +19,8 @@ import type { RelativeSize } from '../models/relativeSize'
 import DialogComponent from './DialogComponent.vue'
 
 defineProps<{
-  pos: RelativePosition
-  size: RelativeSize
+  pos?: RelativePosition | 'center'
+  size?: RelativeSize
   title: string
   message: string
   blocking?: boolean
@@ -31,5 +31,7 @@ defineProps<{
 .message {
   text-align: center;
   margin: 0;
+  padding-bottom: 2em;
+  white-space: pre-line;
 }
 </style>

--- a/web/src/core/components/LoginDialogComponent.vue
+++ b/web/src/core/components/LoginDialogComponent.vue
@@ -1,7 +1,6 @@
 <template>
   <DialogComponent
     :pos="pos"
-    :size="size"
     :buttons="{
       success: t('login.login'),
       cancel: false,
@@ -12,7 +11,7 @@
       maximize: false,
     }"
     :blocking="false"
-    :resizable="false"
+    :resizable="true"
     :disabled="disabled"
     @click-success="onClickSuccess"
   >
@@ -50,7 +49,6 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import DialogComponent from '@/core/components/DialogComponent.vue'
 import type { RelativePosition } from '@/core/models/relativePosition'
-import type { RelativeSize } from '@/core/models/relativeSize'
 import type { CreateAuthTokenDto } from '../models/dto'
 import type { ValidationErrors } from '../utils/types'
 import LockIconComponent from './LockIconComponent.vue'
@@ -66,8 +64,7 @@ const emit = defineEmits<{
 }>()
 
 defineProps<{
-  pos: RelativePosition
-  size: RelativeSize
+  pos?: RelativePosition | 'center'
   disabled?: boolean
   errorMessage?: string
   validationErrors?: ValidationErrors<CreateAuthTokenDto>
@@ -87,7 +84,7 @@ const onClickSuccess = () => {
 
 .hfs-login-dialog__container {
   width: 100%;
-  height: 100%;
+  margin-bottom: 1em;
   display: flex;
   flex-direction: column;
   gap: 0.5em;

--- a/web/src/core/components/WindowComponent.vue
+++ b/web/src/core/components/WindowComponent.vue
@@ -9,13 +9,15 @@
     ref="windowEl"
     @mousedown="onWindowMouseDown"
     @touchstart="onWindowMouseDown"
-    :style="{
-      width: currentSize.w + '%',
-      height: currentSize.h + '%',
-      top: currentPos.y + '%',
-      left: currentPos.x + '%',
-      ...dragStyle,
-    }"
+    :style="
+      isDragResizeReady && {
+        width: currentSize.w + '%',
+        height: currentSize.h + '%',
+        top: currentPos.y + '%',
+        left: currentPos.x + '%',
+        ...dragStyle,
+      }
+    "
   >
     <div class="hfs-window__header">
       <div
@@ -89,8 +91,8 @@ const emit = defineEmits<{
 }>()
 
 const props = defineProps<{
-  pos?: RelativePosition
-  size: RelativeSize
+  pos?: RelativePosition | 'center'
+  size?: RelativeSize
   title?: string
   hideTitlebar?: boolean
   controls?: WindowTitleBarControls
@@ -106,6 +108,7 @@ const windowEl = ref<HTMLElement>()
 const isBlocked = ref<boolean>(false)
 const windowIdx = store.processes.size
 const {
+  isDragResizeReady,
   currentSize,
   currentPos,
   dragStyle,
@@ -115,10 +118,13 @@ const {
   onDragStart,
   onResizeStart,
 } = useDragResize(
-  props.pos ??
-    new RelativePosition(windowIdx + 50 - props.size.w / 2, windowIdx + 50 - props.size.h / 2),
-  props.size,
   windowEl,
+  props.pos
+    ? props.pos
+    : !props.pos && props.size
+      ? new RelativePosition(windowIdx + 50 - props.size.w / 2, windowIdx + 50 - props.size.h / 2)
+      : undefined,
+  props.size,
   undefined,
   undefined,
   () => {

--- a/web/src/core/views/LoginView.vue
+++ b/web/src/core/views/LoginView.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="login">
+  <div class="hfs-login-view">
     <LoginDialogComponent
+      pos="center"
+      class="hfs-login-view__login-dialog"
       v-if="showLoginDialog"
-      :size="new RelativeSize(25, 30)"
       :disabled="isSubmitting"
       :loading-spinner="isSubmitting && SpinnerTypes.dots"
-      :pos="new RelativePosition(39, 36)"
       :error-message="errorMessage"
       :validation-errors="validationErrors"
       @submit="onSubmit"
@@ -21,8 +21,6 @@ import LoginDialogComponent, { type LoginSubmitEvent } from '../components/Login
 import { SpinnerTypes } from '../components/SpinnerIconComponent.vue'
 import { AuthUser } from '../models/auth_user'
 import type { APIResponse, CreateAuthTokenDto } from '../models/dto'
-import { RelativePosition } from '../models/relativePosition'
-import { RelativeSize } from '../models/relativeSize'
 import { useCoreStore } from '../stores'
 import type { ValidationErrors } from '../utils/types'
 
@@ -75,8 +73,12 @@ const checkAuth = async () => {
 </script>
 
 <style scoped lang="scss">
-.login {
+.hfs-login-view {
   width: 100vw;
   height: 100vh;
+}
+
+.hfs-login-view__login-dialog {
+  min-width: 350px;
 }
 </style>

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -56,7 +56,7 @@ export const i18nOptions: I18nOptions = {
         accountUpdatedAt: 'Updated at',
         accountDeleteConfirmTitle: 'Confirm deletion',
         accountDeleteConfirmMessage:
-          'Deleting this account will affect your transactions and balances. Would you really like to delete this account? | Deleting this account will affect your transactions and balances. Would you really like to delete these ({count}) accounts?',
+          'Deleting this account will affect your transactions and balances. \nWould you really like to delete this account? | Deleting this account will affect your transactions and balances. Would you really like to delete these ({count}) accounts?',
         createTransaction: 'Create Transaction',
         editTransaction: 'Edit Transaction',
         transactionDescription: 'Description',
@@ -135,7 +135,7 @@ export const i18nOptions: I18nOptions = {
         accountUpdatedAt: '更新日',
         accountDeleteConfirmTitle: '本当にこのアカウントを削除しますか？',
         accountDeleteConfirmMessage:
-          'アカウントを削除すると金額情報や取引記録も影響されます。本当に削除しますか？',
+          'アカウントを削除すると金額情報や\n取引記録も影響されます。\n本当に削除しますか？',
         createTransaction: '取引を作成',
         editTransaction: '取引を修正',
         transactionDescription: '説明',

--- a/web/src/modules/cashbunny/components/AccountDataTableComponent.vue
+++ b/web/src/modules/cashbunny/components/AccountDataTableComponent.vue
@@ -15,16 +15,14 @@
       @click-success="onSuccessConfirmDeleteDialog"
       @click-close="onCloseConfirmDeleteDialog"
       @click-cancel="onCloseConfirmDeleteDialog"
-      :pos="new RelativePosition(40, 40)"
-      :size="new RelativeSize(20, 20)"
+      pos="center"
       :title="t('cashbunny.accountDeleteConfirmTitle')"
       :message="t('cashbunny.accountDeleteConfirmMessage', rowsToDelete.length)"
       :blocking="true"
     />
     <AccountFormDialogComponent
       v-if="isCreate || rowToEdit"
-      :pos="new RelativePosition(25, 25)"
-      :size="new RelativeSize(50, 50)"
+      pos="center"
       :title="t('cashbunny.addAccount')"
       :next-account-index="data.length"
       :account="rowToEdit ?? undefined"
@@ -46,8 +44,6 @@ import DataTableComponent, {
   type DataTableRowDeleteEvent,
   type DataTableRowEditEvent,
 } from '@/core/components/DataTableComponent.vue'
-import { RelativePosition } from '@/core/models/relativePosition'
-import { RelativeSize } from '@/core/models/relativeSize'
 import type { AccountDto } from '../models/dto'
 import { useCashbunnyStore } from '../stores'
 import AccountFormDialogComponent from './AccountFormDialogComponent.vue'

--- a/web/src/modules/cashbunny/components/AccountFormDialogComponent.vue
+++ b/web/src/modules/cashbunny/components/AccountFormDialogComponent.vue
@@ -72,8 +72,8 @@ const emit = defineEmits<{
 }>()
 
 const props = defineProps<{
-  pos: RelativePosition
-  size: RelativeSize
+  pos?: RelativePosition | 'center'
+  size?: RelativeSize
   title: string
   nextAccountIndex: number
   account?: AccountDto
@@ -135,11 +135,11 @@ const onClickSubmit = async () => {
 
 <style scoped lang="scss">
 .container {
-  width: 100%;
-  height: 100%;
+  min-width: 300px;
   display: flex;
   flex-direction: column;
   gap: 0.5em;
+  margin-bottom: 1em;
 }
 
 .title {

--- a/web/src/modules/cashbunny/components/OverviewComponent.vue
+++ b/web/src/modules/cashbunny/components/OverviewComponent.vue
@@ -95,9 +95,9 @@ const {
   onResizeStart: onRightSectionResizeStart,
   dragStyle,
 } = useDragResize(
+  rightSection,
   new RelativePosition(0, 0),
   new RelativeSize(30, 0),
-  rightSection,
   overviewContainer,
   {
     resize: {

--- a/web/src/modules/cashbunny/components/TransactionDataTableComponent.vue
+++ b/web/src/modules/cashbunny/components/TransactionDataTableComponent.vue
@@ -15,16 +15,14 @@
       @click-success="onSuccessConfirmDeleteDialog"
       @click-close="onCloseConfirmDeleteDialog"
       @click-cancel="onCloseConfirmDeleteDialog"
-      :pos="new RelativePosition(40, 40)"
-      :size="new RelativeSize(20, 20)"
+      pos="center"
       :title="t('cashbunny.transactionDeleteConfirmTitle')"
       :message="t('cashbunny.transactionDeleteConfirmMessage', rowsToDelete.length)"
       :blocking="true"
     />
     <TransactionFormDialogComponent
       v-if="isCreate || rowToEdit"
-      :pos="new RelativePosition(25, 25)"
-      :size="new RelativeSize(50, 50)"
+      pos="center"
       :title="t('cashbunny.addTransaction')"
       :transaction="clickedData ?? undefined"
       @success="onTransactionFormSuccess"
@@ -47,8 +45,6 @@ import DataTableComponent, {
   type DataTableRowDeleteEvent,
   type DataTableRowEditEvent,
 } from '@/core/components/DataTableComponent.vue'
-import { RelativePosition } from '@/core/models/relativePosition'
-import { RelativeSize } from '@/core/models/relativeSize'
 import type { TransactionDto } from '../models/dto'
 import { useCashbunnyStore } from '../stores'
 import TransactionFormDialogComponent from './TransactionFormDialogComponent.vue'

--- a/web/src/modules/cashbunny/components/TransactionFormDialogComponent.vue
+++ b/web/src/modules/cashbunny/components/TransactionFormDialogComponent.vue
@@ -86,8 +86,8 @@ const emit = defineEmits<{
 }>()
 
 const props = defineProps<{
-  pos: RelativePosition
-  size: RelativeSize
+  pos?: RelativePosition | 'center'
+  size?: RelativeSize
   title: string
   transaction?: TransactionDto
 }>()
@@ -163,11 +163,11 @@ onMounted(async () => {
 
 <style scoped lang="scss">
 .container {
-  width: 100%;
-  height: 100%;
+  min-width: 300px;
   display: flex;
   flex-direction: column;
   gap: 0.5em;
+  margin-bottom: 1em;
 }
 
 .title {

--- a/web/src/modules/cashbunny/views/CashbunnyView.vue
+++ b/web/src/modules/cashbunny/views/CashbunnyView.vue
@@ -1,8 +1,7 @@
 <template>
   <ErrorDialogComponent
     v-if="errorTitle && errorMessage"
-    :pos="new RelativePosition(40, 40)"
-    :size="new RelativeSize(20, 20)"
+    pos="center"
     :title="errorTitle"
     :message="errorMessage"
   />
@@ -18,8 +17,6 @@
 import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ErrorDialogComponent from '@/core/components/ErrorDialogComponent.vue'
-import { RelativePosition } from '@/core/models/relativePosition'
-import { RelativeSize } from '@/core/models/relativeSize'
 import { useCoreStore } from '@/core/stores'
 import CashbunnySplashComponent from '../components/CashbunnySplashComponent.vue'
 import CashbunnyWindowComponent from '../components/CashbunnyWindowComponent.vue'

--- a/web/src/modules/portfolio/components/AboutDialogComponent.vue
+++ b/web/src/modules/portfolio/components/AboutDialogComponent.vue
@@ -21,8 +21,8 @@ import type { RelativePosition } from '@/core/models/relativePosition'
 import type { RelativeSize } from '@/core/models/relativeSize'
 
 defineProps<{
-  pos: RelativePosition
-  size: RelativeSize
+  pos?: RelativePosition | 'center'
+  size?: RelativeSize
 }>()
 
 const { t } = useI18n()

--- a/web/src/modules/portfolio/components/ContactFormDialogComponent.vue
+++ b/web/src/modules/portfolio/components/ContactFormDialogComponent.vue
@@ -32,8 +32,8 @@ const emit = defineEmits<{
 }>()
 
 defineProps<{
-  pos: RelativePosition
-  size: RelativeSize
+  pos?: RelativePosition | 'center'
+  size?: RelativeSize
 }>()
 
 const { t } = useI18n()

--- a/web/src/modules/portfolio/components/PortfolioWindowComponent.vue
+++ b/web/src/modules/portfolio/components/PortfolioWindowComponent.vue
@@ -90,15 +90,13 @@
     </div>
     <ContactFormDialogComponent
       v-if="showContactFormDialog"
-      :pos="new RelativePosition(40, 40)"
-      :size="new RelativeSize(20, 20)"
+      pos="center"
       @submit="onClickSuccessContactFormDialog"
       @click-close="onClickCloseContactFormDialog"
     />
     <AboutDialogComponent
       v-if="showAboutDialog"
-      :pos="new RelativePosition(40, 40)"
-      :size="new RelativeSize(20, 20)"
+      pos="center"
       @click-close="onClickCloseAboutDialog"
     />
   </WindowComponent>


### PR DESCRIPTION
Things changed:
- size and pos props are optional for useDraggable and the Window component
- the initial size and pos use either the arguments/props, or are calculated to relative size based on the HTML element's current dimensions (getBoundingClientRect())