### PR TITLE
FE HFS - Add an option for windows to fit content

### DIFF
--- a/web/src/core/components/DialogComponent.vue
+++ b/web/src/core/components/DialogComponent.vue
@@ -11,6 +11,7 @@
       }
     "
     :resizable="resizable"
+    :fit-content="fitContent"
     @click-close="emit('clickClose')"
   >
     <template #title>
@@ -61,6 +62,7 @@ const emit = defineEmits<{
 const props = defineProps<{
   pos?: RelativePosition | 'center'
   size?: RelativeSize
+  fitContent?: boolean
   title?: string
   blocking?: boolean
   buttons: {

--- a/web/src/core/components/LoginDialogComponent.vue
+++ b/web/src/core/components/LoginDialogComponent.vue
@@ -1,6 +1,7 @@
 <template>
   <DialogComponent
     :pos="pos"
+    :fit-content="true"
     :buttons="{
       success: t('login.login'),
       cancel: false,
@@ -11,7 +12,7 @@
       maximize: false,
     }"
     :blocking="false"
-    :resizable="true"
+    :resizable="false"
     :disabled="disabled"
     @click-success="onClickSuccess"
   >

--- a/web/src/core/components/WindowComponent.vue
+++ b/web/src/core/components/WindowComponent.vue
@@ -11,8 +11,8 @@
     @touchstart="onWindowMouseDown"
     :style="
       isDragResizeReady && {
-        width: currentSize.w + '%',
-        height: currentSize.h + '%',
+        width: fitContent ? undefined : currentSize.w + '%',
+        height: fitContent ? undefined : currentSize.h + '%',
         top: currentPos.y + '%',
         left: currentPos.x + '%',
         ...dragStyle,
@@ -93,6 +93,7 @@ const emit = defineEmits<{
 const props = defineProps<{
   pos?: RelativePosition | 'center'
   size?: RelativeSize
+  fitContent?: boolean
   title?: string
   hideTitlebar?: boolean
   controls?: WindowTitleBarControls

--- a/web/src/core/views/LoginView.vue
+++ b/web/src/core/views/LoginView.vue
@@ -51,7 +51,7 @@ const onSubmit = async (payload: LoginSubmitEvent) => {
       if (error.code === AxiosError.ERR_BAD_REQUEST) {
         const res = error.response?.data as APIResponse<null>
         errorMessage.value = res.error?.message || ''
-        validationErrors.value = { ...validationErrors.value, ...res.error?.validation_errors }
+        validationErrors.value = { username: '', password: '', ...res.error?.validation_errors }
       }
     }
   } finally {


### PR DESCRIPTION
Windows now have a new prop `fitContent` where they won't use calculated sizes, but rather be sized based on the content.
Once this is set, it will render `resize` prop useless